### PR TITLE
Potential fix for code scanning alert no. 2: Incorrect conversion between integer types

### DIFF
--- a/util/basic.go
+++ b/util/basic.go
@@ -166,7 +166,7 @@ func ToInt8(v interface{}) int8 {
 	case float64:
 		return int8(v)
 	case []byte:
-		result, err := strconv.Atoi(string(v))
+		result, err := strconv.ParseInt(string(v), 10, 8)
 		if err != nil {
 			return 0
 		}


### PR DESCRIPTION
Potential fix for [https://github.com/aidapedia/gdk/security/code-scanning/2](https://github.com/aidapedia/gdk/security/code-scanning/2)

In general, to safely convert from a wider integer (or architecture-dependent `int`) to a narrower type like `int8`, validate that the value lies within the target type’s range before casting. For parsing from strings, prefer `strconv.ParseInt` with the correct bit size instead of `strconv.Atoi`, or add explicit bounds checks using constants from `math`.

For this specific code, we need to address conversions that go from `strconv.Atoi`’s `int` result to `int8`. Within the provided snippet, the problematic path is in `ToInt8` for the `[]byte` case:

```go
case []byte:
    result, err := strconv.Atoi(string(v))
    if err != nil {
        return 0
    }
    return int8(result)
```

The minimal, behavior-preserving fix is to replace `strconv.Atoi` with `strconv.ParseInt` using base 10 and bit size 8, and then cast the `int64` result to `int8`. `ParseInt` will fail with an error if the number is outside the `int8` range, so we avoid silent truncation. This keeps behavior for valid `int8` values identical, while now returning `0` for out-of-range or malformed values, which matches the function’s existing pattern on parse errors.

Concretely, in `util/basic.go`:
- In the `ToInt8` function, inside the `case []byte:` block (around lines 168–173), replace:
  - `result, err := strconv.Atoi(string(v))` and `return int8(result)`
- With:
  - `result, err := strconv.ParseInt(string(v), 10, 8)` and `return int8(result)`

No new imports are required because `strconv` is already imported. Other cases (like the `string` case in `ToInt8` and other integer-type casts) are out of scope for the reported alert; we only change the shown, flagged code.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
